### PR TITLE
Changed check in TerminateYarn to stop infinite loop

### DIFF
--- a/Lib/Core/IdSchedulerOfThread.pas
+++ b/Lib/Core/IdSchedulerOfThread.pas
@@ -218,7 +218,7 @@ var
 begin
   Assert(AYarn<>nil);
   LYarn := TIdYarnOfThread(AYarn);
-  if (LYarn.Thread <> nil) and (not LYarn.Thread.Suspended) then begin
+  if (LYarn.Thread <> nil) and (not LYarn.Thread.Stopped) then begin
     // Is still running and will free itself
     LYarn.Thread.Stop;
     // Dont free the yarn. The thread frees it (IdThread.pas)


### PR DESCRIPTION
I have experienced infinete loops, because the Thread was stopped and terminated, but not free'ed or suspended.