### PR TITLE
Fix for TIdSSPINTLMAuthentication

### DIFF
--- a/Lib/Protocols/IdAuthenticationSSPI.pas
+++ b/Lib/Protocols/IdAuthenticationSSPI.pas
@@ -418,6 +418,8 @@ type
     destructor Destroy; override;
     function Authentication: string; override;
     function KeepAlive: Boolean; override;
+    function AuthorizationAttemptMerited(
+      const AProxyPasswordeExists, AOnProxyAuthorizationExists: Boolean): Boolean; override;
     property Domain: String read GetDomain write SetDomain;
   end;
 
@@ -1052,8 +1054,6 @@ function TCustomSSPIConnectionContext.UpdateAndGenerateReply
 var
   fOutBuff: SecBuffer;
 begin
-  Result := False;
-
   { check credentials }
   CheckCredentials;
   { prepare input buffer }
@@ -1306,6 +1306,13 @@ begin
     Delete(S, 1, Length(Domain) + 1);
   end;
   inherited SetUserName(S);
+end;
+
+function TIdSSPINTLMAuthentication.AuthorizationAttemptMerited(
+  const AProxyPasswordeExists, AOnProxyAuthorizationExists: Boolean): Boolean;
+begin
+  // This type of authentication does not require either
+  Result := True;
 end;
 
 destructor TIdSSPINTLMAuthentication.Destroy;

--- a/Lib/Protocols/IdHTTP.pas
+++ b/Lib/Protocols/IdHTTP.pas
@@ -2379,8 +2379,20 @@ begin
 
   // TODO: get rid of this check here.  Let ProxyParams.Authentication validate
   // the username/password as needed.  Don't validate OnProxyAuthorization unless
-  // wnAskTheProgram is requested...  
-  Result := Assigned(OnProxyAuthorization) or (Trim(ProxyParams.ProxyPassword) <> '');
+  // wnAskTheProgram is requested...
+  //  Result := Assigned(OnProxyAuthorization) or (Trim(ProxyParams.ProxyPassword) <> '');
+
+  // MForte 10/26/2018: Rather than getting rid of the above check, which might
+  // cause adverse consequences that I can't imagine, I moved the logic into
+  // the TIdAuthentication class.
+  // TIdAuthentication.AuthorizationAttemptMerited has exactly the same logic as
+  // above, while TIdSSPINTLMAuthentication.AuthorizationAttemptMerited always
+  // returns True.
+  Result :=
+    ProxyParams.Authentication.AuthorizationAttemptMerited(
+        (Trim(ProxyParams.ProxyPassword) <> ''),
+        Assigned(OnProxyAuthorization)
+      );
 
   if not Result then begin
     Exit;


### PR DESCRIPTION
TIdSSPINTLMAuthentication currently does not work.  This appears to have been an issue for quite some time as I found other folks that appear to have had the same issue way back in 2012:
http://codeverge.com/embarcadero.delphi.winsock/tidhttp-not-retrying-after-407-res/1073579
Here is another thread that seems to be related to the issue:
https://stackoverflow.com/questions/15111605/indy-tidhttp-integrated-security-authentication-issue-with-sspi
Note that there is an existing open issue, but I'm not sure if my fix addresses it, or if it is for something different?:
https://github.com/IndySockets/Indy/issues/87
Here is what I changed:
IdAuthentication.pas - Added virtual method TIdAuthentication.AuthorizationAttemptMerited.  Contains exact same logic that used to be TIdCustomHTTP.DoOnProxyAuthorization.
TIdHTTP.pas - Updated TIdCustomHTTP.DoOnProxyAuthorization to call TIdAuthentication.AuthorizationAttemptMerited rather than doing the logic itself.
IdAuthenticationSSPI.pas - TIdSSPINTLMAuthentication.AuthorizationAttemptMerited overrides default logic.  For this class authorization is always merited as no username or password is needed.