### PR TITLE
Fix incorrect value of the 'Last-Modified' HTTP header value as set by TIdResponseHeaderInfo.

### DIFF
--- a/Lib/Protocols/IdHTTPHeaderInfo.pas
+++ b/Lib/Protocols/IdHTTPHeaderInfo.pas
@@ -1172,7 +1172,7 @@ begin
   end;
   if FLastModified > 0 then
   begin
-    RawHeaders.Values['Last-Modified'] := DateTimeGMTToHttpStr(FLastModified); {do not localize}
+    RawHeaders.Values['Last-Modified'] := LocalDateTimeToHttpStr(FLastModified); {do not localize}
   end;
 end;
 


### PR DESCRIPTION
Fix incorrect value of the 'Last-Modified' HTTP header value as set by TIdResponseHeaderInfo.

In TIdResponseHeaderInfo.SetHeaders the 'Last-Modified' HTTP header value is set using DateTimeGMTToHttpStr instead of LocalDateTimeToHttpStr, even though the value of the FLastModified field should and will contain a local date time value (as is demonstrated by TIdEntityHeaderInfo.ProcessHeaders, TIdRequestHeaderInfo.SetHeaders, TIdHTTPResponseInfo.SetHeaders, TIdHTTPResponseInfo.SmartServeFile and TIdHTTPAppResponse.GetDateVariable).