### PR TITLE
Allow to terminate Recv/Send methods if fSSL was destroyed

### DIFF
--- a/Lib/Protocols/IdSSLOpenSSL.pas
+++ b/Lib/Protocols/IdSSLOpenSSL.pas
@@ -3828,6 +3828,7 @@ var
   ret, err: Integer;
 begin
   repeat
+    if fSSL = nil then Break;  
     ret := SSL_read(fSSL, PByte(ABuffer), Length(ABuffer));
     if ret > 0 then begin
       Result := ret;
@@ -3852,6 +3853,7 @@ var
 begin
   Result := 0;
   repeat
+    if fSSL = nil then Break;
     ret := SSL_write(fSSL, @ABuffer[AOffset], ALength);
     if ret > 0 then begin
       Inc(Result, ret);


### PR DESCRIPTION
I'm using `TIdHTTP`/`SSL` in background thread. 
if I call `Post` method, I have AV after calling `Disconnect` in main thread because `TIdSSLSocket` is destroyed but `TIdSSLSocket.Send` is still executed ....

call-stack (main thread) when TIdSSLSocket is freed:
>     IdSSLOpenSSL.TIdSSLSocket.Destroy
>     System.TObject.Free
>     IdSSLOpenSSL.TIdSSLIOHandlerSocketOpenSSL.Close
>     IdTCPConnection.TIdTCPConnection.Disconnect(???)
>     IdTCPConnection.TIdTCPConnection.Disconnect

AV in `TIdSSLSocket.Send` because `fSSL` is `nil`:

```
function TIdSSLSocket.Send(const ABuffer: TIdBytes; AOffset, ALength: Integer): Integer;
var
  ret, err: Integer;
begin
  Result := 0;
  repeat
    ret := SSL_write(fSSL, @ABuffer[AOffset], ALength); //<<<< AV
```
call-stack for this is

>     IdSSLOpenSSL.TIdSSLSocket.Send(...)
>     IdSSLOpenSSL.TIdSSLIOHandlerSocketOpenSSL.SendEnc(???,???,224)
>     IdSSL.TIdSSLIOHandlerSocketBase.WriteDataToTarget(???,???,224)
>     IdIOHandler.TIdIOHandler.WriteDirect(...)
>     IdIOHandler.TIdIOHandler.WriteBufferFlush(???)
>     IdIOHandler.TIdIOHandler.WriteBufferFlush
>     IdIOHandler.TIdIOHandler.WriteBufferClose
>     IdHTTP.TIdHTTPProtocol.BuildAndSendRequest(???)
>     IdHTTP.TIdCustomHTTP.ConnectToHost($7EA93560,???)
>     IdHTTP.TIdCustomHTTP.DoRequest(???,'https://.....',$7E91CBF0,$7E9B7AA0,(...))
>     IdHTTP.TIdCustomHTTP.Post('https://......',$8663B0,$7E9B7AA0)

if we add checking for `nil` for `fSSL` we can avoid AV