### PR TITLE
Correctly define timezone functions for FPC

### DIFF
--- a/Lib/Core/IdCompilerDefines.inc
+++ b/Lib/Core/IdCompilerDefines.inc
@@ -1422,6 +1422,9 @@
     {$DEFINE HAS_UInt16}
     {$DEFINE HAS_Int32}
     {$DEFINE HAS_UInt32}
+    {$DEFINE HAS_GetLocalTimeOffset}
+    {$DEFINE HAS_UniversalTimeToLocal}
+    {$DEFINE HAS_LocalTimeToUniversal}
   {$ENDIF}
   {$IFDEF FPC_2_6_4_OR_ABOVE}
     {$DEFINE HAS_PInt8}
@@ -1441,9 +1444,6 @@
   {$IFDEF FPC_3_1_1_OR_ABOVE}
     {$DEFINE HAS_STATIC_TThread_ForceQueue} // requires rev 37359+
   {$ENDIF}
-  {$DEFINE HAS_GetLocalTimeOffset} // TODO: when was GetLocalTimeOffset() introduced?
-  {$DEFINE HAS_UniversalTimeToLocal} // TODO: when was UniversalTimeToLocal() introduced?
-  {$DEFINE HAS_LocalTimeToUniversal} // TODO: when was LocalTimeToUniversal() introduced?
 {$ENDIF}
 
 {$IFDEF DOTNET}

--- a/Lib/FCL/IdCompilerDefines.inc
+++ b/Lib/FCL/IdCompilerDefines.inc
@@ -1422,6 +1422,9 @@
     {$DEFINE HAS_UInt16}
     {$DEFINE HAS_Int32}
     {$DEFINE HAS_UInt32}
+    {$DEFINE HAS_GetLocalTimeOffset}
+    {$DEFINE HAS_UniversalTimeToLocal}
+    {$DEFINE HAS_LocalTimeToUniversal}
   {$ENDIF}
   {$IFDEF FPC_2_6_4_OR_ABOVE}
     {$DEFINE HAS_PInt8}
@@ -1441,9 +1444,6 @@
   {$IFDEF FPC_3_1_1_OR_ABOVE}
     {$DEFINE HAS_STATIC_TThread_ForceQueue} // requires rev 37359+
   {$ENDIF}
-  {$DEFINE HAS_GetLocalTimeOffset} // TODO: when was GetLocalTimeOffset() introduced?
-  {$DEFINE HAS_UniversalTimeToLocal} // TODO: when was UniversalTimeToLocal() introduced?
-  {$DEFINE HAS_LocalTimeToUniversal} // TODO: when was LocalTimeToUniversal() introduced?
 {$ENDIF}
 
 {$IFDEF DOTNET}

--- a/Lib/Protocols/IdCompilerDefines.inc
+++ b/Lib/Protocols/IdCompilerDefines.inc
@@ -1422,6 +1422,9 @@
     {$DEFINE HAS_UInt16}
     {$DEFINE HAS_Int32}
     {$DEFINE HAS_UInt32}
+    {$DEFINE HAS_GetLocalTimeOffset}
+    {$DEFINE HAS_UniversalTimeToLocal}
+    {$DEFINE HAS_LocalTimeToUniversal}
   {$ENDIF}
   {$IFDEF FPC_2_6_4_OR_ABOVE}
     {$DEFINE HAS_PInt8}
@@ -1441,9 +1444,6 @@
   {$IFDEF FPC_3_1_1_OR_ABOVE}
     {$DEFINE HAS_STATIC_TThread_ForceQueue} // requires rev 37359+
   {$ENDIF}
-  {$DEFINE HAS_GetLocalTimeOffset} // TODO: when was GetLocalTimeOffset() introduced?
-  {$DEFINE HAS_UniversalTimeToLocal} // TODO: when was UniversalTimeToLocal() introduced?
-  {$DEFINE HAS_LocalTimeToUniversal} // TODO: when was LocalTimeToUniversal() introduced?
 {$ENDIF}
 
 {$IFDEF DOTNET}

--- a/Lib/SuperCore/IdCompilerDefines.inc
+++ b/Lib/SuperCore/IdCompilerDefines.inc
@@ -1422,6 +1422,9 @@
     {$DEFINE HAS_UInt16}
     {$DEFINE HAS_Int32}
     {$DEFINE HAS_UInt32}
+    {$DEFINE HAS_GetLocalTimeOffset}
+    {$DEFINE HAS_UniversalTimeToLocal}
+    {$DEFINE HAS_LocalTimeToUniversal}
   {$ENDIF}
   {$IFDEF FPC_2_6_4_OR_ABOVE}
     {$DEFINE HAS_PInt8}
@@ -1441,9 +1444,6 @@
   {$IFDEF FPC_3_1_1_OR_ABOVE}
     {$DEFINE HAS_STATIC_TThread_ForceQueue} // requires rev 37359+
   {$ENDIF}
-  {$DEFINE HAS_GetLocalTimeOffset} // TODO: when was GetLocalTimeOffset() introduced?
-  {$DEFINE HAS_UniversalTimeToLocal} // TODO: when was UniversalTimeToLocal() introduced?
-  {$DEFINE HAS_LocalTimeToUniversal} // TODO: when was LocalTimeToUniversal() introduced?
 {$ENDIF}
 
 {$IFDEF DOTNET}

--- a/Lib/System/IdCompilerDefines.inc
+++ b/Lib/System/IdCompilerDefines.inc
@@ -1422,6 +1422,9 @@
     {$DEFINE HAS_UInt16}
     {$DEFINE HAS_Int32}
     {$DEFINE HAS_UInt32}
+    {$DEFINE HAS_GetLocalTimeOffset}
+    {$DEFINE HAS_UniversalTimeToLocal}
+    {$DEFINE HAS_LocalTimeToUniversal}
   {$ENDIF}
   {$IFDEF FPC_2_6_4_OR_ABOVE}
     {$DEFINE HAS_PInt8}
@@ -1441,9 +1444,6 @@
   {$IFDEF FPC_3_1_1_OR_ABOVE}
     {$DEFINE HAS_STATIC_TThread_ForceQueue} // requires rev 37359+
   {$ENDIF}
-  {$DEFINE HAS_GetLocalTimeOffset} // TODO: when was GetLocalTimeOffset() introduced?
-  {$DEFINE HAS_UniversalTimeToLocal} // TODO: when was UniversalTimeToLocal() introduced?
-  {$DEFINE HAS_LocalTimeToUniversal} // TODO: when was LocalTimeToUniversal() introduced?
 {$ENDIF}
 
 {$IFDEF DOTNET}


### PR DESCRIPTION
UniversalTimeToLocal and LocalTimeToUniversal() where introduced
via https://bugs.freepascal.org/view.php?id=17435 -> 2.6.1
GetLocalTimeOffset was added via
https://svn.freepascal.org/cgi-bin/viewvc.cgi?view=revision&revision=22296
to fixes branch of FPC 2.6.x before 2.6.2 release date
-> FPC 2.6.2 has been released in February 2013