### PR TITLE
fix compiling issues for IdStack in FPC

### DIFF
--- a/Lib/System/IdStackConsts.pas
+++ b/Lib/System/IdStackConsts.pas
@@ -554,6 +554,7 @@ SocketOptionName.UseLoopback;//  Bypass hardware when possible.
   Id_WSAEFAULT          = EFAULT;
   Id_WSAEINVAL          = EINVAL;
   Id_WSAEMFILE          = EMFILE;
+  Id_WSAEAGAIN          = EAGAIN;
   Id_WSAEWOULDBLOCK     = EWOULDBLOCK;
   Id_WSAEINPROGRESS     = EINPROGRESS;
   Id_WSAEALREADY        = EALREADY;
@@ -600,6 +601,7 @@ SocketOptionName.UseLoopback;//  Bypass hardware when possible.
   Id_WSAEFAULT          = EFAULT;
   Id_WSAEINVAL          = EINVAL;
   Id_WSAEMFILE          = EMFILE;
+  Id_WSAEAGAIN          = EAGAIN;
   Id_WSAEWOULDBLOCK     = EWOULDBLOCK;
   Id_WSAEINPROGRESS     = EINPROGRESS;
   Id_WSAEALREADY        = EALREADY;
@@ -658,6 +660,7 @@ SocketOptionName.UseLoopback;//  Bypass hardware when possible.
   Id_WSAEFAULT          = ESysEFAULT;
   Id_WSAEINVAL          = ESysEINVAL;
   Id_WSAEMFILE          = ESysEMFILE;
+  Id_WSAEAGAIN          = ESysEAGAIN;
   Id_WSAEWOULDBLOCK     = ESysEWOULDBLOCK;
   Id_WSAEINPROGRESS     = ESysEINPROGRESS;
   Id_WSAEALREADY        = ESysEALREADY;

--- a/Lib/System/IdStackLibc.pas
+++ b/Lib/System/IdStackLibc.pas
@@ -1107,7 +1107,10 @@ end;
 
 function TIdStackLibc.WouldBlock(const AResult: Integer): Boolean;
 begin
-  Result := (AResult in [EAGAIN, EWOULDBLOCK, EINPROGRESS]);
+  if (AResult = Id_WSAEAGAIN) or (AResult = Id_WSAEWOULDBLOCK) or (AResult = Id_WSAEINPROGRESS) then
+    Result := True
+  else
+    Result := False;
 end;
 
 function TIdStackLibc.SupportsIPv4: Boolean;

--- a/Lib/System/IdStackLinux.pas
+++ b/Lib/System/IdStackLinux.pas
@@ -1093,7 +1093,10 @@ end;
 
 function TIdStackLinux.WouldBlock(const AResult: Integer): Boolean;
 begin
-  Result := (AResult in [EAGAIN, EWOULDBLOCK, EINPROGRESS]);
+  if (AResult = Id_WSAEAGAIN) or (AResult = Id_WSAEWOULDBLOCK) or (AResult = Id_WSAEINPROGRESS) then
+    Result := True
+  else
+    Result := False;
 end;
 
 function TIdStackLinux.SupportsIPv4: Boolean;

--- a/Lib/System/IdStackUnix.pas
+++ b/Lib/System/IdStackUnix.pas
@@ -221,6 +221,7 @@ implementation
 uses
   netdb,
   unix,
+  termio,
   IdResourceStrings,
   IdResourceStringsUnix,
   IdException,
@@ -1055,7 +1056,10 @@ end;
 
 function TIdStackUnix.WouldBlock(const AResult: Integer): Boolean;
 begin
-  Result := (AResult in [EAGAIN, EWOULDBLOCK, EINPROGRESS]);
+  if (AResult = Id_WSAEAGAIN) or (AResult = Id_WSAEWOULDBLOCK) or (AResult = Id_WSAEINPROGRESS) then
+    Result := True
+  else
+    Result := False;
 end;
 
 function TIdStackUnix.SupportsIPv4: Boolean;

--- a/Lib/System/IdStackVCLPosix.pas
+++ b/Lib/System/IdStackVCLPosix.pas
@@ -1295,7 +1295,10 @@ end;
 
 function TIdStackVCLPosix.WouldBlock(const AResult: Integer): Boolean;
 begin
-  Result := (AResult in [EAGAIN, EWOULDBLOCK, EINPROGRESS]);
+  if (AResult = Id_WSAEAGAIN) or (AResult = Id_WSAEWOULDBLOCK) or (AResult = Id_WSAEINPROGRESS) then
+    Result := True
+  else
+    Result := False;
 end;
 
 procedure TIdStackVCLPosix.WriteChecksum(s: TIdStackSocketHandle;


### PR DESCRIPTION
- termio is needed for FIONBIO identifier
- add EAGAIN identifier to IdStackConsts
- use appropriate types from IdStackConsts (not sure if defined for all targets)
- if-else instead of in..range because EAGAIN and EWOULDBLOCK
have often the same value (see https://stackoverflow.com/a/7003379)
and so FPC might report a range error