### PR TITLE
Fix compiling for FPC on Windows

### DIFF
--- a/Lib/Protocols/IdGlobalProtocols.pas
+++ b/Lib/Protocols/IdGlobalProtocols.pas
@@ -592,17 +592,24 @@ uses
     {$ENDIF}
   {$ENDIF}
   IdIPAddress,
+  {$IFDEF HAS_GetLocalTimeOffset}
+    DateUtils,
+  {$ENDIF}
   {$IFDEF UNIX}
     {$IFDEF USE_VCL_POSIX}
-  DateUtils,
-  Posix.SysStat, Posix.SysTime, Posix.Time, Posix.Unistd,
+      {$IFNDEF HAS_GetLocalTimeOffset}
+        DateUtils,
+      {$ENDIF}
+      Posix.SysStat, Posix.SysTime, Posix.Time, Posix.Unistd,
     {$ELSE}
       {$IFDEF KYLIXCOMPAT}
-  Libc,
+        Libc,
       {$ELSE}
         {$IFDEF USE_BASEUNIX}
-  BaseUnix, Unix,
-  DateUtils,
+          BaseUnix, Unix,
+          {$IFNDEF HAS_GetLocalTimeOffset}
+            DateUtils,
+          {$ENDIF}
         {$ENDIF}
       {$ENDIF}
     {$ENDIF}


### PR DESCRIPTION
IdGlobalProtocols.pas(1347,48) Error: Identifier not found "UniversalTimeToLocal"
IdGlobalProtocols.pas(1375,5) Error: Identifier not found "LocalTimeToUniversal"
IdGlobalProtocols.pas(2792,48) Error: Identifier not found "UniversalTimeToLocal"
IdGlobalProtocols.pas(3047,48) Error: Identifier not found "UniversalTimeToLocal"

after #272 it uses the functions above but unit Dateutils isn't loaded for Windows