### PR TITLE
Define global TLSVersion in IdSSL

### DIFF
--- a/Lib/Protocols/IdSSL.pas
+++ b/Lib/Protocols/IdSSL.pas
@@ -117,8 +117,8 @@ type
   TIdServerSSLClass = class of TIdServerIOHandlerSSLBase;
 
 type
-  TIdSSLVersion = (sslvSSLv2, sslvSSLv23, sslvSSLv3, sslvTLSv1, sslvTLSv1_1, sslvTLSv1_2);
-  TIdSSLVersions = set of TIdSSLVersion;
+  TIdTLSVersion = (tlsvTLS_flexible, tlsvTLSv1_0, tlsvTLSv1_1, tlsvTLSv1_2, tlsvTLSv1_3);
+  TIdTLSVersions = set of TIdTLSVersion;
 
 Procedure RegisterSSL(const AProduct, AVendor, ACopyright,
   ADescription, AURL : String;

--- a/Lib/Protocols/IdSSL.pas
+++ b/Lib/Protocols/IdSSL.pas
@@ -116,6 +116,10 @@ type
   TIdClientSSLClass = class of TIdSSLIOHandlerSocketBase;
   TIdServerSSLClass = class of TIdServerIOHandlerSSLBase;
 
+type
+  TIdSSLVersion = (sslvSSLv2, sslvSSLv23, sslvSSLv3, sslvTLSv1, sslvTLSv1_1, sslvTLSv1_2);
+  TIdSSLVersions = set of TIdSSLVersion;
+
 Procedure RegisterSSL(const AProduct, AVendor, ACopyright,
   ADescription, AURL : String;
   const AClientClass : TIdClientSSLClass; const AServerClass : TIdServerSSLClass);

--- a/Lib/Protocols/IdSSLOpenSSL.pas
+++ b/Lib/Protocols/IdSSLOpenSSL.pas
@@ -234,8 +234,6 @@ uses
   IdYarn;
 
 type
-  TIdSSLVersion = (sslvSSLv2, sslvSSLv23, sslvSSLv3, sslvTLSv1,sslvTLSv1_1,sslvTLSv1_2);
-  TIdSSLVersions = set of TIdSSLVersion;
   TIdSSLMode = (sslmUnassigned, sslmClient, sslmServer, sslmBoth);
   TIdSSLVerifyMode = (sslvrfPeer, sslvrfFailIfNoPeerCert, sslvrfClientOnce);
   TIdSSLVerifyModeSet = set of TIdSSLVerifyMode;

--- a/Lib/Protocols/IdSSLOpenSSL.pas
+++ b/Lib/Protocols/IdSSLOpenSSL.pas
@@ -234,6 +234,8 @@ uses
   IdYarn;
 
 type
+  TIdSSLVersion = (sslvSSLv2, sslvSSLv23, sslvSSLv3, sslvTLSv1, sslvTLSv1_1, sslvTLSv1_2);
+  TIdSSLVersions = set of TIdSSLVersion;
   TIdSSLMode = (sslmUnassigned, sslmClient, sslmServer, sslmBoth);
   TIdSSLVerifyMode = (sslvrfPeer, sslvrfFailIfNoPeerCert, sslvrfClientOnce);
   TIdSSLVerifyModeSet = set of TIdSSLVerifyMode;


### PR DESCRIPTION
this allows to have one set of TLS versions for all SSL/TLS IO handler