### PR TITLE
February-29th-workaround

### DIFF
--- a/Lib/Protocols/IdFTPListParseUnix.pas
+++ b/Lib/Protocols/IdFTPListParseUnix.pas
@@ -749,7 +749,13 @@ begin
     {$ENDIF}
     begin
       Inc(wYear);
-      LI.ModifiedDate := EncodeDate(wYear, wMonth, wDay) + EncodeTime(wHour, wMin, wSec, wMSec);
+      if (wMonth = 2) and (wDay = 29) and (not IsLeapYear(wYear)) then
+      begin
+        {temporary workaround for Leap Year, February 29th. Encode with day - 1, but do NOT decrement wDay since this will give us the wrong day when we adjust/re-calculate the date later}
+        LI.ModifiedDate := EncodeDate(wYear, wMonth, wDay - 1) + EncodeTime(wHour, wMin, wSec, wMSec);
+      end else begin
+        LI.ModifiedDate := EncodeDate(wYear, wMonth, wDay) + EncodeTime(wHour, wMin, wSec, wMSec);
+      end;
     end;
   end;
 


### PR DESCRIPTION
There's a patch (or workaround) for a problem that indy might get a FTP-date which is exactly one year behind. To fix this indy is increasing the year in some cases.
If the year is increased there is no check for february 29th so it might lead to a incorrect date (i. e. 29.02.2021) and will raise an EConvertError