### PR TITLE
Fix for issue #377 -  #301 broke IdFTP in Active mode

### DIFF
--- a/Lib/Protocols/IdFTP.pas
+++ b/Lib/Protocols/IdFTP.pas
@@ -2121,7 +2121,7 @@ begin
           LSocketList.Add(Socket.Binding.Handle);
           LSocketList.Add(LDataSocket);
 
-          IOHandler.Write(ACommand);
+          IOHandler.WriteLn(ACommand);
 
           LReadList := nil;
           if not LSocketList.SelectReadList(LReadList, ListenTimeout) then begin


### PR DESCRIPTION
The original code used SendCmd, a combination of IOHandler.WriteLn(ACommand) and GetResponse([125, 150, 154]).
The code after the latest changes (#301) executed IOHandler.Write(ACommand) and GetResponse...
As the capture proved, the missing CRLF triggered the timeout.
In previous comments to the Indy project for this issue (#377) I used Zoe's demo project for testing against test.rebex.net (a demo FTP site).
I also provided binary and parsed captures of the traffic for the previous code executing successfully, and for the new code failing with the timeout.
Lastly, I made a frame-by-frame comparison between both, indicating where the error was triggered (command LIST without the <EOL>).