### PR TITLE
Fix BIO_ctrl parg argument in BIO_set_nbio_accept

### DIFF
--- a/Lib/Protocols/IdSSLOpenSSLHeaders.pas
+++ b/Lib/Protocols/IdSSLOpenSSLHeaders.pas
@@ -25481,9 +25481,11 @@ end;
 //* #define BIO_set_nbio(b,n)	BIO_ctrl(b,BIO_C_SET_NBIO,(n),NULL) */
 function BIO_set_nbio_accept(b : PBIO; n : TIdC_INT) : TIdC_LONG;
 {$IFDEF USE_INLINE} inline; {$ENDIF}
+const
+  a: array[0..1] of TIdAnsiChar = (TIdAnsiChar('a'), TIdAnsiChar(#0));
 begin
   if n <> 0 then begin
-    Result := BIO_ctrl(b, BIO_C_SET_ACCEPT, 1, PIdAnsiChar('a'));
+    Result := BIO_ctrl(b, BIO_C_SET_ACCEPT, 1, @a[0]);
   end else begin
     Result := BIO_ctrl(b, BIO_C_SET_ACCEPT, 1, nil);
   end;


### PR DESCRIPTION
**Problem**
- There is a direct Char -> PChar cast in `IdSSLOpenSSLHeaders.BIO_set_nbio_accept`.

**Background**
Casting a Character type to a Character Pointer type is non-portable between different versions of Delphi.

In Delphi 11, there's a significant breaking change in the code generation around Char/AnsiChar -> PChar/PAnsiChar casts.
Rather than taking the ordinal value of the character and converting it to a pointer, a new single-character string is constructed and the pointer to that string is returned instead.

See:
- [Wrong results in cast from PWideChar to Char](https://quality.embarcadero.com/browse/RSP-29639)
- [Bug in PWideChar](https://quality.embarcadero.com/browse/RSP-29772)
- [Bad codegen breaks Winapi.Windows.CharUpperW()](https://quality.embarcadero.com/browse/RSP-31498)