### PR TITLE
Allow BIO_set_nbio_accept to be inlined again

### DIFF
--- a/Lib/Protocols/IdSSLOpenSSLHeaders.pas
+++ b/Lib/Protocols/IdSSLOpenSSLHeaders.pas
@@ -25480,10 +25480,13 @@ end;
 
 //* #define BIO_set_nbio(b,n)	BIO_ctrl(b,BIO_C_SET_NBIO,(n),NULL) */
 function BIO_set_nbio_accept(b : PBIO; n : TIdC_INT) : TIdC_LONG;
-const
-  a: array[0..1] of TIdAnsiChar = (TIdAnsiChar('a'), TIdAnsiChar(#0));
+{$IFDEF USE_INLINE} inline; {$ENDIF}
+var
+  a: array[0..1] of TIdAnsiChar;
 begin
   if n <> 0 then begin
+    a[0] := TIdAnsiChar('a');
+    a[1] := TIdAnsiChar(#0);
     Result := BIO_ctrl(b, BIO_C_SET_ACCEPT, 1, @a[0]);
   end else begin
     Result := BIO_ctrl(b, BIO_C_SET_ACCEPT, 1, nil);


### PR DESCRIPTION
It turns out that `const` declared within a function counts as a "local symbol" for the purposes of inlining and fails the build.