### PR TITLE
Sending the UTF8 command to the POP3 Server

### DIFF
--- a/Lib/Protocols/IdPOP3.pas
+++ b/Lib/Protocols/IdPOP3.pas
@@ -587,6 +587,18 @@ begin
   FSASLMechanisms.Assign(AValue);
 end;
 
+procedure TIdPOP3.SendUTF8IfAdvertised;
+var
+  Capa : string;
+begin
+  for Capa in FCapabilities do
+    if TextStartsWith(Capa, 'UTF8 ') then
+    begin
+      SendCmd('UTF8','');
+      exit;
+    end;
+end;
+
 procedure TIdPOP3.Connect;
 var
   S: String;
@@ -619,6 +631,7 @@ begin
     if FAutoLogin then begin
       Login;
     end;
+    SendUTF8IfAdvertised;
   except
     Disconnect(False);
     raise;


### PR DESCRIPTION
Newer POP3 Server are not delivering the emails correct, if the clients don't tell them that they are UTF8 compatible. https://tools.ietf.org/html/rfc6856.html

This patch sends the UTF8 command, if the server is requesting it.