### PR TITLE
Fixed definition of time_t

### DIFF
--- a/Lib/System/IdCTypes.pas
+++ b/Lib/System/IdCTypes.pas
@@ -139,14 +139,14 @@ type
   {$IFDEF HAS_TIME_T}
   TIdC_TIMET = time_t;
   {$ELSE}
-    {$IFDEF HAS_PtrUInt}
-  TIdC_TIMET = PtrUInt;
+    {$IFDEF HAS_PtrInt}
+  TIdC_TIMET = PtrInt;
     {$ELSE}
       {$IFDEF CPU32}
-  TIdC_TIMET = TIdC_UINT32;
+  TIdC_TIMET = TIdC_INT32;
       {$ENDIF}
       {$IFDEF CPU64}
-  TIdC_TIMET = TIdC_UINT64;
+  TIdC_TIMET = TIdC_INT64;
       {$ENDIF}
     {$ENDIF}
   {$ENDIF}
@@ -261,14 +261,14 @@ type
   {$IFDEF HAS_TIME_T}
   TIdC_TIMET = time_t;
   {$ELSE}
-    {$IFDEF HAS_NativeUInt}
-  TIdC_TIMET = NativeUInt;
+    {$IFDEF HAS_NativeInt}
+  TIdC_TIMET = NativeInt;
     {$ELSE}
       {$IFDEF CPU32}
-  TIdC_TIMET = TIdC_UINT32;
+  TIdC_TIMET = TIdC_INT32;
       {$ENDIF}
       {$IFDEF CPU64}
-  TIdC_TIMET = TIdC_UINT64;
+  TIdC_TIMET = TIdC_INT64;
       {$ENDIF}
     {$ENDIF}
   {$ENDIF}


### PR DESCRIPTION
Currently time_t is a unsigned integer on 32-bit and unsinged int64 on 64-bit. But it should be a signed one.

> The Unix [`time_t`](https://en.wikipedia.org/wiki/Time_t) data type that represents a point in time is, on many platforms, a [signed integer](https://en.wikipedia.org/wiki/Integer_(computer_science)), traditionally of 32 [bits](https://en.wikipedia.org/wiki/Bit) (but see below), directly encoding the Unix time number as described in the preceding section.
> [...]
> In some newer operating systems, time_t has been widened to 64 bits.
> [...]
> There was originally some controversy over whether the Unix time_t should be signed or unsigned. If unsigned, its range in the future would be doubled, postponing the 32-bit overflow (by 68 years). However, it would then be incapable of representing times prior to the epoch. The consensus is for time_t to be signed, and this is the usual practice.

(Source: [Wikipedia](https://en.wikipedia.org/wiki/Time_t))

And as a additional source:
```
typedef long                          __time32_t;
typedef __int64                       __time64_t;
```
Thats the definition in Windows Kits 10.0.18362.0