### PR TITLE
Fix for #208 - TIdSMTP - correctly handle answer, if Initial-Response is not supported

### DIFF
--- a/Lib/Protocols/IdSASLCollection.pas
+++ b/Lib/Protocols/IdSASLCollection.pas
@@ -229,6 +229,15 @@ begin
           Exit; // this mechanism is not supported
         end;
       end else begin
+        if TrimRight(AClient.LastCmdResult.Text.Text) = 'VXNlcm5hbWU6' then // 'Username:'
+        begin
+          // request for username --> Initial-Response failed, we have to send username again
+          AClient.SendCmd(AEncoder.Encode(S), []);//[334, 504]);
+          if CheckStrFail(AClient.LastCmdResult.Code, AOkReplies, AContinueReplies) then begin
+            ASASL.FinishAuthenticate;
+            Exit; // this mechanism is not supported
+          end;
+        end;
         AuthStarted := True;
       end;
     end;

--- a/Lib/Protocols/IdSMTP.pas
+++ b/Lib/Protocols/IdSMTP.pas
@@ -218,6 +218,7 @@ type
     // This is just an internal flag we use to determine if we already authenticated to the server.
     FDidAuthenticate: Boolean;
     FValidateAuthLoginCapability: Boolean;
+    FCanAttemptIR: Boolean;
     // FSASLMechanisms : TIdSASLList;
     FSASLMechanisms : TIdSASLEntries;
     //
@@ -248,6 +249,7 @@ type
   published
     property AuthType: TIdSMTPAuthenticationType read FAuthType write FAuthType
      default DEF_SMTP_AUTH;
+    property CanAttemptIR: Boolean read FCanAttemptIR write FCanAttemptIR default True;
     property Host;
     property Password;
     property Port default IdPORT_SMTP;
@@ -363,7 +365,7 @@ begin
       end;
     satSASL:
       begin
-        SASLMechanisms.LoginSASL('AUTH', FHost, IdGSKSSN_smtp, ['235'], ['334'], Self, Capabilities); {do not localize}
+        SASLMechanisms.LoginSASL('AUTH', FHost, IdGSKSSN_smtp, ['235'], ['334'], Self, Capabilities, 'AUTH', FCanAttemptIR); {do not localize}
         FDidAuthenticate := True;
       end;
   end;
@@ -389,6 +391,7 @@ begin
   inherited InitComponent;
   FSASLMechanisms := TIdSASLEntries.Create(Self);
   FAuthType := DEF_SMTP_AUTH;
+  FCanAttemptIR := True;
   FValidateAuthLoginCapability := True;
 end;
 


### PR DESCRIPTION
Fix for #208 - If Initial-Response is not supported, the server might fail to handle the request completely or the server might ask for the username, because the server does not handle the provided username after AUTH LOGIN.

At the moment, the login is cancelled at this moment, so it does not work at all.

So I added functionality to answer the request for the username correctly and continue.
**Note:**
The encoded string 'Username:' is hardcoded directly in the code at the moment. A constant would be better, but I did not know where to put it correctly.

In addition I added a property CanAttemptIR to TIdSMTP, so one can switch off the try with IR in case the server cannot handle this at all. This was supported already, but the functionality was not exposed, because this parameter was always set to True.