### PR TITLE
Update IdCompressorZLib.pas

### DIFF
--- a/Lib/Protocols/IdCompressorZLib.pas
+++ b/Lib/Protocols/IdCompressorZLib.pas
@@ -70,7 +70,7 @@ type
   TIdCompressorZLib = class(TIdZLibCompressorBase)
   protected
     function GetIsReady : Boolean; override;
-    procedure InternalDecompressStream(LZstream: TZStreamRec; AIOHandler : TIdIOHandler;
+    procedure InternalDecompressStream(var LZstream: TZStreamRec; AIOHandler : TIdIOHandler;
       AOutStream: TStream);
   public
 
@@ -105,7 +105,7 @@ const
 { TIdCompressorZLib }
 
 procedure TIdCompressorZLib.InternalDecompressStream(
-  LZstream: TZStreamRec; AIOHandler: TIdIOHandler; AOutStream: TStream);
+  var LZstream: TZStreamRec; AIOHandler: TIdIOHandler; AOutStream: TStream);
 {Note that much of this is taken from the ZLibEx unit and adapted to use the IOHandler}
 var
   zresult  : Integer;
@@ -172,7 +172,11 @@ begin
     repeat
       LZstream.next_out := @outBuffer[0];
       LZstream.avail_out := bufferSize;
-      DCheck(inflate(LZstream,Z_NO_FLUSH));
+      zresult := inflate(LZstream, Z_NO_FLUSH);
+      if zresult <> Z_BUF_ERROR then
+      begin
+        DCheck(zresult);
+      end;
       outSize := bufferSize - LZstream.avail_out;
       AOutStream.Write(outBuffer, outSize);
     until (LZstream.avail_in = 0) and (LZstream.avail_out > 0);


### PR DESCRIPTION
1. Z_BUF_ERROR is just a warning, not an error, it should be ignored.
2. Since a newer version of zlib is used, LZstream needs to be changed from passing value ​​to passing address.