### PR TITLE
Move GetProxyTargetHost and GetURIHost downto base class (TIdSSLIOHan…

### DIFF
--- a/Lib/Protocols/IdSSL.pas
+++ b/Lib/Protocols/IdSSL.pas
@@ -76,6 +76,8 @@ type
     fPassThrough: Boolean;
     fIsPeer : Boolean;
     FURIToCheck : String;
+    function GetProxyTargetHost: string;
+    function GetURIHost(const AURIToCheck: String): string;
     procedure InitComponent; override;
     function RecvEnc(var ABuffer: TIdBytes): Integer; virtual; abstract;
     function SendEnc(const ABuffer: TIdBytes; const AOffset, ALength: Integer): Integer; virtual; abstract;
@@ -161,7 +163,7 @@ var
 implementation
 
 uses
-  SysUtils;
+  SysUtils, IdCustomTransparentProxy, IdURI;
 
 {$I IdSymbolDeprecatedOff.inc}
 
@@ -184,6 +186,49 @@ end;
 {$I IdSymbolDeprecatedOn.inc}
 
 { TIdSSLIOHandlerSocketBase }
+
+function TIdSSLIOHandlerSocketBase.GetProxyTargetHost: string;
+var
+  // under ARC, convert a weak reference to a strong reference before working with it
+  LTransparentProxy, LNextTransparentProxy: TIdCustomTransparentProxy;
+begin
+  Result := '';
+  // RLebeau: not reading from the property as it will create a
+  // default Proxy object if one is not already assigned...
+  LTransparentProxy := FTransparentProxy;
+  if Assigned(LTransparentProxy) then
+  begin
+    if LTransparentProxy.Enabled then
+    begin
+      repeat
+        LNextTransparentProxy := LTransparentProxy.ChainedProxy;
+        if not Assigned(LNextTransparentProxy) then
+          Break;
+        if not LNextTransparentProxy.Enabled then
+          Break;
+        LTransparentProxy := LNextTransparentProxy;
+      until False;
+      Result := LTransparentProxy.Host;
+    end;
+  end;
+
+end;
+
+function TIdSSLIOHandlerSocketBase.GetURIHost(const AURIToCheck: String): string;
+var
+  LURI: TIdURI;
+begin
+  Result := '';
+  if URIToCheck <> '' then
+  begin
+    LURI := TIdURI.Create(URIToCheck);
+    try
+      Result := LURI.Host;
+    finally
+      LURI.Free;
+    end;
+  end;
+end;
 
 procedure TIdSSLIOHandlerSocketBase.InitComponent;
 begin

--- a/Lib/Protocols/IdSSL.pas
+++ b/Lib/Protocols/IdSSL.pas
@@ -77,7 +77,7 @@ type
     fIsPeer : Boolean;
     FURIToCheck : String;
     function GetProxyTargetHost: string;
-    function GetURIHost(const AURIToCheck: String): string;
+    function GetURIHost : string;
     procedure InitComponent; override;
     function RecvEnc(var ABuffer: TIdBytes): Integer; virtual; abstract;
     function SendEnc(const ABuffer: TIdBytes; const AOffset, ALength: Integer): Integer; virtual; abstract;
@@ -214,7 +214,7 @@ begin
 
 end;
 
-function TIdSSLIOHandlerSocketBase.GetURIHost(const AURIToCheck: String): string;
+function TIdSSLIOHandlerSocketBase.GetURIHost : string;
 var
   LURI: TIdURI;
 begin

--- a/Lib/Protocols/IdSSLOpenSSL.pas
+++ b/Lib/Protocols/IdSSLOpenSSL.pas
@@ -3044,7 +3044,7 @@ begin
     end;
   end;
   if LMode = sslmClient then begin
-    LHost := GetURIHost(URIToCheck);
+    LHost := GetURIHost;
     if LHost = '' then
     begin
       LHost := GetProxyTargetHost;

--- a/Lib/Protocols/IdSSLOpenSSL.pas
+++ b/Lib/Protocols/IdSSLOpenSSL.pas
@@ -2999,48 +2999,6 @@ var
   LMode: TIdSSLMode;
   LHost: string;
 
-  // TODO: move the following to TIdSSLIOHandlerSocketBase...
-
-  function GetURIHost: string;
-  var
-    LURI: TIdURI;
-  begin
-    Result := '';
-    if URIToCheck <> '' then
-    begin
-      LURI := TIdURI.Create(URIToCheck);
-      try
-        Result := LURI.Host;
-      finally
-        LURI.Free;
-      end;
-    end;
-  end;
-
-  function GetProxyTargetHost: string;
-  var
-    // under ARC, convert a weak reference to a strong reference before working with it
-    LTransparentProxy, LNextTransparentProxy: TIdCustomTransparentProxy;
-  begin
-    Result := '';
-    // RLebeau: not reading from the property as it will create a
-    // default Proxy object if one is not already assigned...
-    LTransparentProxy := FTransparentProxy;
-    if Assigned(LTransparentProxy) then
-    begin
-      if LTransparentProxy.Enabled then
-      begin
-        repeat
-          LNextTransparentProxy := LTransparentProxy.ChainedProxy;
-          if not Assigned(LNextTransparentProxy) then Break;
-          if not LNextTransparentProxy.Enabled then Break;
-          LTransparentProxy := LNextTransparentProxy;
-        until False;
-        Result := LTransparentProxy.Host;
-      end;
-    end;
-  end;
-
 begin
   Assert(Binding<>nil);
   if not Assigned(fSSLSocket) then begin
@@ -3086,7 +3044,7 @@ begin
     end;
   end;
   if LMode = sslmClient then begin
-    LHost := GetURIHost;
+    LHost := GetURIHost(URIToCheck);
     if LHost = '' then
     begin
       LHost := GetProxyTargetHost;

--- a/Lib/Protocols/IdSSLOpenSSL.pas
+++ b/Lib/Protocols/IdSSLOpenSSL.pas
@@ -693,8 +693,6 @@ uses
   IdExceptionCore,
   IdResourceStrings,
   IdThreadSafe,
-  IdCustomTransparentProxy,
-  IdURI,
   SysUtils,
   SyncObjs;
 


### PR DESCRIPTION
…dlerSocketBase) so both TaurusTLS and Indy's SSL support can use the same code.