### PR TITLE
Ftp algs command

### DIFF
--- a/Lib/Protocols/IdFTPServer.pas
+++ b/Lib/Protocols/IdFTPServer.pas
@@ -2232,7 +2232,7 @@ begin
 
   //ALGS  - RFC 6384
   LCmd := CommandHandlers.Add;
-  LCmd.NormalReply.NumericCode := 200;
+  LCmd.NormalReply.NumericCode := 202;
   LCmd.NormalReply.Text.Text := 'Command not implemented, superfluous at this site'; {Do not localize}
   LCmd.Command := 'ALGS';    {Do not Localize}
   LCmd.Description.Text := 'Syntax: ALGS (STATUS64|ENABLE64|DISABLE64)'; {do not localize}

--- a/Lib/Protocols/IdFTPServer.pas
+++ b/Lib/Protocols/IdFTPServer.pas
@@ -2230,6 +2230,13 @@ begin
   LCmd.NormalReply.NumericCode := 200;
   LCmd.Description.Text := 'Syntax: SSCN [ON|OFF]'; {do not localize}
 
+  //ALGS  - RFC 6384
+  LCmd := CommandHandlers.Add;
+  LCmd.NormalReply.NumericCode := 200;
+  LCmd.NormalReply.Text.Text := 'Command not implemented, superfluous at this site'; {Do not localize}
+  LCmd.Command := 'ALGS';    {Do not Localize}
+  LCmd.Description.Text := 'Syntax: ALGS (STATUS64|ENABLE64|DISABLE64)'; {do not localize}
+
   //CPSV <CRLF>
   LCmd := CommandHandlers.Add;
   LCmd.Command := 'CPSV';    {Do not Localize}


### PR DESCRIPTION
Command specified by:
https://www.rfc-editor.org/rfc/rfc6384.html#section-11

FTP servers (as opposed
   to ALGs) MUST NOT perform any actions upon receiving the ALGS
   command.  However, FTP servers MUST still send a response.  If FTP
   servers recognize the ALGS command, the best course of action would
   be to return a 202 response:

      202 Command not implemented, superfluous at this site
