### PR TITLE
Solaris does not allow an IPv4 socket and an IPv6 socket to listen on the same port at the same time.

### DIFF
--- a/Lib/Core/IdCustomTCPServer.pas
+++ b/Lib/Core/IdCustomTCPServer.pas
@@ -985,7 +985,7 @@ end;
 // to listen on the same port at the same time! Windows does not
 // have that problem...
 {$DEFINE CanCreateTwoBindings}
-{$IFDEF LINUX} // should this be UNIX instead?
+{$IF DEFINED(LINUX) or DEFINED(SOLARIS)} // should this be UNIX instead?
   {$UNDEF CanCreateTwoBindings}
 {$ENDIF}
 {$IFDEF ANDROID}

--- a/Lib/Core/IdCustomTCPServer.pas
+++ b/Lib/Core/IdCustomTCPServer.pas
@@ -985,7 +985,10 @@ end;
 // to listen on the same port at the same time! Windows does not
 // have that problem...
 {$DEFINE CanCreateTwoBindings}
-{$IF DEFINED(LINUX) or DEFINED(SOLARIS)} // should this be UNIX instead?
+{$IFDEF LINUX} // should this be UNIX instead?
+  {$UNDEF CanCreateTwoBindings}
+{$ENDIF}
+{$IFDEF SOLARIS}
   {$UNDEF CanCreateTwoBindings}
 {$ENDIF}
 {$IFDEF ANDROID}

--- a/Lib/Core/IdUDPServer.pas
+++ b/Lib/Core/IdUDPServer.pas
@@ -293,7 +293,10 @@ end;
 // to listen on the same port at the same time! Windows does not
 // have that problem...
 {$DEFINE CanCreateTwoBindings}
-{$IF DEFINED(LINUX) or DEFINED(SOLARIS)} // should this be UNIX instead?
+{$IFDEF LINUX} // should this be UNIX instead?
+  {$UNDEF CanCreateTwoBindings}
+{$ENDIF}
+{$IFDEF SOLARIS}
   {$UNDEF CanCreateTwoBindings}
 {$ENDIF}
 {$IFDEF ANDROID}

--- a/Lib/Core/IdUDPServer.pas
+++ b/Lib/Core/IdUDPServer.pas
@@ -293,7 +293,7 @@ end;
 // to listen on the same port at the same time! Windows does not
 // have that problem...
 {$DEFINE CanCreateTwoBindings}
-{$IFDEF LINUX} // should this be UNIX instead?
+{$IF DEFINED(LINUX) or DEFINED(SOLARIS)} // should this be UNIX instead?
   {$UNDEF CanCreateTwoBindings}
 {$ENDIF}
 {$IFDEF ANDROID}


### PR DESCRIPTION
Solaris does not allow an IPv4 socket and an IPv6 socket to listen on the same port at the same time.
Tested with Solaris 11.4.