### PR TITLE
add unit scope for Windows and Registry units

### DIFF
--- a/Lib/Core/IdCustomTCPServer.pas
+++ b/Lib/Core/IdCustomTCPServer.pas
@@ -425,7 +425,11 @@ implementation
 uses
   {$IFDEF VCL_2010_OR_ABOVE}
     {$IFDEF WINDOWS}
-  Windows,
+      {$IFDEF VCL_XE2_OR_ABOVE}
+      WinAPI.Windows,
+      {$ELSE}
+      Windows,
+      {$ENDIF}
     {$ENDIF}
   {$ENDIF}
   IdGlobalCore,

--- a/Lib/Core/IdIOHandler.pas
+++ b/Lib/Core/IdIOHandler.pas
@@ -792,7 +792,11 @@ uses
     {$ENDIF}
   {$ENDIF}
   {$IFDEF WIN32_OR_WIN64}
-  Windows,
+    {$IFDEF VCL_XE2_OR_ABOVE}
+    WinAPI.Windows,
+    {$ELSE}
+    Windows,
+    {$ENDIF}
   {$ENDIF}
   {$IFDEF USE_VCL_POSIX}
     {$IFDEF OSX}

--- a/Lib/Core/IdIOHandlerSocket.pas
+++ b/Lib/Core/IdIOHandlerSocket.pas
@@ -234,7 +234,11 @@ uses
     {$ENDIF}
   {$ENDIF}
   {$IFDEF WIN32_OR_WIN64 }
-  Windows,
+    {$IFDEF VCL_XE2_OR_ABOVE}
+    WinAPI.Windows,
+    {$ELSE}
+    Windows,
+    {$ENDIF}
   {$ENDIF}
   SysUtils,
   IdStack,

--- a/Lib/Core/IdIOHandlerStack.pas
+++ b/Lib/Core/IdIOHandlerStack.pas
@@ -209,7 +209,11 @@ uses
   Posix.SysTime,
   {$ENDIF}
   {$IFDEF WINDOWS}
-  Windows,
+    {$IFDEF VCL_XE2_OR_ABOVE}
+    WinAPI.Windows,
+    {$ELSE}
+    Windows,
+    {$ENDIF}
   {$ENDIF}
   IdAntiFreezeBase, IdResourceStringsCore, IdStackConsts, IdException,
   IdComponent, IdIOHandler, IdCustomTransparentProxy;

--- a/Lib/Core/IdScheduler.pas
+++ b/Lib/Core/IdScheduler.pas
@@ -121,7 +121,11 @@ uses
   {$ENDIF}
   {$IFDEF VCL_2010_OR_ABOVE}
     {$IFDEF WINDOWS}
-  Windows,
+      {$IFDEF VCL_XE2_OR_ABOVE}
+      WinAPI.Windows,
+      {$ELSE}
+      Windows,
+      {$ENDIF}
     {$ENDIF}
   {$ENDIF}
   {$IFDEF USE_VCL_POSIX}

--- a/Lib/Core/IdSchedulerOfThreadPool.pas
+++ b/Lib/Core/IdSchedulerOfThreadPool.pas
@@ -116,7 +116,11 @@ implementation
 uses
   {$IFDEF VCL_2010_OR_ABOVE}
     {$IFDEF WINDOWS}
-  Windows,
+      {$IFDEF VCL_XE2_OR_ABOVE}
+      WinAPI.Windows,
+      {$ELSE}
+      Windows,
+      {$ENDIF}
     {$ENDIF}
   {$ENDIF}
   IdGlobal, SysUtils;

--- a/Lib/Core/IdSync.pas
+++ b/Lib/Core/IdSync.pas
@@ -182,7 +182,11 @@ uses
   {$ENDIF}
   {$IFDEF VCL_2010_OR_ABOVE}
     {$IFDEF WINDOWS}
-  Windows,
+      {$IFDEF VCL_XE2_OR_ABOVE}
+      WinAPI.Windows,
+      {$ELSE}
+      Windows,
+      {$ENDIF}
     {$ENDIF}
   {$ENDIF}
   {$IFDEF USE_VCL_POSIX}

--- a/Lib/Core/IdThreadSafe.pas
+++ b/Lib/Core/IdThreadSafe.pas
@@ -237,7 +237,11 @@ implementation
 uses
   {$IFDEF VCL_2010_OR_ABOVE}
     {$IFDEF WINDOWS}
-  Windows,
+      {$IFDEF VCL_XE2_OR_ABOVE}
+      WinAPI.Windows,
+      {$ELSE}
+      Windows,
+      {$ENDIF}
     {$ENDIF}
   {$ENDIF}
   {$IFDEF VCL_XE3_OR_ABOVE}

--- a/Lib/Core/IdUDPServer.pas
+++ b/Lib/Core/IdUDPServer.pas
@@ -196,7 +196,11 @@ implementation
 uses
   {$IFDEF VCL_2010_OR_ABOVE}
     {$IFDEF WINDOWS}
-  Windows,
+      {$IFDEF VCL_XE2_OR_ABOVE}
+      WinAPI.Windows,
+      {$ELSE}
+      Windows,
+      {$ENDIF}
     {$ENDIF}
   {$ENDIF}
   IdGlobalCore, SysUtils;

--- a/Lib/Protocols/IdGlobalProtocols.pas
+++ b/Lib/Protocols/IdGlobalProtocols.pas
@@ -618,7 +618,11 @@ uses
   {$ENDIF}
   {$IFDEF WINDOWS}
   Messages,
-  Registry,
+    {$IFDEF VCL_XE2_OR_ABOVE}
+    System.Win.Registry,
+    {$ELSE}
+    Registry,
+    {$ENDIF}
   {$ENDIF}
   {$IFDEF DOTNET}
   System.IO,


### PR DESCRIPTION
TL;DR: Win64 projects don't list all needed unit scope names.

When trying to compile the Indy libraries for 64-bit, not all unit scope names were defined in the project (couldn't find the Windows or Registry units). Instead of adding unit scope names to every 64-bit package (like they are in the 32-bit packages) for all versions of Delphi (since XE2 when 64-bit compilers were introduced) or requiring Delphi developers to add them to their own Delphi options, just add compiler directives for the handful of places in the source that need it.

I found "VCL_XE2_OR_ABOVE" already defined and convenient so just used that for both Windows and Registry units.