### PR TITLE
add unit scope names to 64-bit projects, remove conditional scoped names from code

### DIFF
--- a/Lib/Core/IdCustomTCPServer.pas
+++ b/Lib/Core/IdCustomTCPServer.pas
@@ -425,7 +425,7 @@ implementation
 uses
   {$IFDEF VCL_2010_OR_ABOVE}
     {$IFDEF WINDOWS}
-  {$IFDEF VCL_XE2_OR_ABOVE}Winapi.Windows{$ELSE}Windows{$ENDIF},
+    Windows,
     {$ENDIF}
   {$ENDIF}
   IdGlobalCore,

--- a/Lib/Core/IdIOHandler.pas
+++ b/Lib/Core/IdIOHandler.pas
@@ -792,7 +792,7 @@ uses
     {$ENDIF}
   {$ENDIF}
   {$IFDEF WIN32_OR_WIN64}
-  {$IFDEF VCL_XE2_OR_ABOVE}Winapi.Windows{$ELSE}Windows{$ENDIF},
+  Windows,
   {$ENDIF}
   {$IFDEF USE_VCL_POSIX}
     {$IFDEF OSX}

--- a/Lib/Core/IdIOHandlerSocket.pas
+++ b/Lib/Core/IdIOHandlerSocket.pas
@@ -234,7 +234,7 @@ uses
     {$ENDIF}
   {$ENDIF}
   {$IFDEF WIN32_OR_WIN64 }
-  {$IFDEF VCL_XE2_OR_ABOVE}Winapi.Windows{$ELSE}Windows{$ENDIF},
+  Windows,
   {$ENDIF}
   SysUtils,
   IdStack,

--- a/Lib/Core/IdIOHandlerStack.pas
+++ b/Lib/Core/IdIOHandlerStack.pas
@@ -209,7 +209,7 @@ uses
   Posix.SysTime,
   {$ENDIF}
   {$IFDEF WINDOWS}
-  {$IFDEF VCL_XE2_OR_ABOVE}Winapi.Windows{$ELSE}Windows{$ENDIF},
+  Windows,
   {$ENDIF}
   IdAntiFreezeBase, IdResourceStringsCore, IdStackConsts, IdException,
   IdComponent, IdIOHandler, IdCustomTransparentProxy;

--- a/Lib/Core/IdScheduler.pas
+++ b/Lib/Core/IdScheduler.pas
@@ -121,7 +121,7 @@ uses
   {$ENDIF}
   {$IFDEF VCL_2010_OR_ABOVE}
     {$IFDEF WINDOWS}
-  {$IFDEF VCL_XE2_OR_ABOVE}Winapi.Windows{$ELSE}Windows{$ENDIF},
+    Windows,
     {$ENDIF}
   {$ENDIF}
   {$IFDEF USE_VCL_POSIX}

--- a/Lib/Core/IdSchedulerOfThreadPool.pas
+++ b/Lib/Core/IdSchedulerOfThreadPool.pas
@@ -116,7 +116,7 @@ implementation
 uses
   {$IFDEF VCL_2010_OR_ABOVE}
     {$IFDEF WINDOWS}
-  {$IFDEF VCL_XE2_OR_ABOVE}Winapi.Windows{$ELSE}Windows{$ENDIF},
+    Windows,
     {$ENDIF}
   {$ENDIF}
   IdGlobal, SysUtils;

--- a/Lib/Core/IdSync.pas
+++ b/Lib/Core/IdSync.pas
@@ -182,7 +182,7 @@ uses
   {$ENDIF}
   {$IFDEF VCL_2010_OR_ABOVE}
     {$IFDEF WINDOWS}
-  {$IFDEF VCL_XE2_OR_ABOVE}Winapi.Windows{$ELSE}Windows{$ENDIF},
+    Windows,
     {$ENDIF}
   {$ENDIF}
   {$IFDEF USE_VCL_POSIX}

--- a/Lib/Core/IdThreadSafe.pas
+++ b/Lib/Core/IdThreadSafe.pas
@@ -237,7 +237,7 @@ implementation
 uses
   {$IFDEF VCL_2010_OR_ABOVE}
     {$IFDEF WINDOWS}
-  {$IFDEF VCL_XE2_OR_ABOVE}Winapi.Windows{$ELSE}Windows{$ENDIF},
+    Windows,
     {$ENDIF}
   {$ENDIF}
   {$IFDEF VCL_XE3_OR_ABOVE}

--- a/Lib/Core/IdUDPServer.pas
+++ b/Lib/Core/IdUDPServer.pas
@@ -196,7 +196,7 @@ implementation
 uses
   {$IFDEF VCL_2010_OR_ABOVE}
     {$IFDEF WINDOWS}
-  {$IFDEF VCL_XE2_OR_ABOVE}Winapi.Windows{$ELSE}Windows{$ENDIF},
+    Windows,
     {$ENDIF}
   {$ENDIF}
   IdGlobalCore, SysUtils;

--- a/Lib/Core/IndyCore370.dproj
+++ b/Lib/Core/IndyCore370.dproj
@@ -140,7 +140,15 @@
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-        <VerInfo_Locale>1033</VerInfo_Locale>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64)'!=''">
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64x)'!=''">
+        <DCC_Namespace>WinAPI;$(DCC_Namespace)</DCC_Namespace>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1)'!=''">
         <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>

--- a/Lib/Core/dclIndyCore370.dproj
+++ b/Lib/Core/dclIndyCore370.dproj
@@ -129,11 +129,13 @@
         <iOS_AppStore1024>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_1024x1024.png</iOS_AppStore1024>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
-        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;Vcl;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-        <VerInfo_Locale>1033</VerInfo_Locale>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64x)'!=''">
+        <DCC_Namespace>Vcl;Winapi;$(DCC_Namespace)</DCC_Namespace>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1)'!=''">
         <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>

--- a/Lib/Protocols/IdFTPCommon.pas
+++ b/Lib/Protocols/IdFTPCommon.pas
@@ -180,8 +180,8 @@ uses
   // to facilite inlining
   {$IFNDEF HAS_GetLocalTimeOffset}
     {$IFDEF HAS_DateUtils_TTimeZone}
-  ,{$IFDEF VCL_XE2_OR_ABOVE}System.TimeSpan{$ELSE}TimeSpan{$ENDIF}
-  ,DateUtils
+    ,TimeSpan
+    ,DateUtils
     {$ENDIF}
   {$ENDIF}
   ;

--- a/Lib/Protocols/IdGlobalProtocols.pas
+++ b/Lib/Protocols/IdGlobalProtocols.pas
@@ -616,10 +616,7 @@ uses
   {$IFDEF HAS_UNIT_DateUtils}
   DateUtils,
   {$ENDIF}
-  {$IFDEF WINDOWS}
-  Messages,
-  {$IFDEF VCL_XE2_OR_ABOVE}System.Win.Registry{$ELSE}Registry{$ENDIF},
-  {$ENDIF}
+  {$IFDEF WINDOWS}Messages,Registry,{$ENDIF}
   {$IFDEF DOTNET}
   System.IO,
   System.Text,
@@ -627,11 +624,7 @@ uses
   IdResourceStringsProtocols,
   IdStack
   {$IFDEF HAS_IOUtils_TPath}
-    {$IFDEF VCL_XE2_OR_ABOVE}
-  , System.IOUtils
-    {$ELSE}
   , IOUtils
-    {$ENDIF}
   {$ENDIF}
   {$IFDEF USE_OBJECT_ARC}
     {$IFDEF HAS_UNIT_Generics_Collections}

--- a/Lib/Protocols/IndyProtocols370.dproj
+++ b/Lib/Protocols/IndyProtocols370.dproj
@@ -140,7 +140,15 @@
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-        <VerInfo_Locale>1033</VerInfo_Locale>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64)'!=''">
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64x)'!=''">
+        <DCC_Namespace>System.Win;Winapi;$(DCC_Namespace)</DCC_Namespace>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1)'!=''">
         <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>

--- a/Lib/Protocols/dclIndyProtocols370.dproj
+++ b/Lib/Protocols/dclIndyProtocols370.dproj
@@ -111,11 +111,13 @@
         <iOS_AppStore1024>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_1024x1024.png</iOS_AppStore1024>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
-        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;Vcl;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-        <VerInfo_Locale>1033</VerInfo_Locale>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64x)'!=''">
+        <DCC_Namespace>Vcl;$(DCC_Namespace)</DCC_Namespace>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1)'!=''">
         <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>

--- a/Lib/System/IdGlobal.pas
+++ b/Lib/System/IdGlobal.pas
@@ -2060,7 +2060,7 @@ uses
     {$IFNDEF DOTNET}
       {$IFNDEF HAS_GetLocalTimeOffset}
         {$IFDEF HAS_DateUtils_TTimeZone}
-  {$IFDEF VCL_XE2_OR_ABOVE}System.TimeSpan{$ELSE}TimeSpan{$ENDIF},
+        TimeSpan,
         {$ENDIF}
       {$ENDIF}
     {$ENDIF}

--- a/Lib/System/IndySystem370.dproj
+++ b/Lib/System/IndySystem370.dproj
@@ -140,7 +140,15 @@
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-        <VerInfo_Locale>1033</VerInfo_Locale>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64)'!=''">
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64x)'!=''">
+        <DCC_Namespace>Winapi;$(DCC_Namespace)</DCC_Namespace>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1)'!=''">
         <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>


### PR DESCRIPTION
I thought this affected more than Delphi 13 but my tests involving the whole XE series, 10.1 Berlin, 11, and 12, all compiled.