### PR TITLE
Fix Delphi 13 $PUSHOPT/$POPOPT and noreturn warnings

### DIFF
--- a/Lib/Core/IdCompilerOptionsPop.inc
+++ b/Lib/Core/IdCompilerOptionsPop.inc
@@ -3,6 +3,7 @@
     {$POP}
   {$ELSE}
     {$IFDEF DCC}
+      {$WARN POPOPT_WITH_NO_MATCHING OFF}
       {$POPOPT}
     {$ENDIF}
   {$ENDIF}

--- a/Lib/Core/IdCompilerOptionsPush.inc
+++ b/Lib/Core/IdCompilerOptionsPush.inc
@@ -3,6 +3,7 @@
     {$PUSH}
   {$ELSE}
     {$IFDEF DCC}
+      {$WARN MISSING_POPOPT OFF}
       {$PUSHOPT}
     {$ENDIF}
   {$ENDIF}

--- a/Lib/Protocols/IdCompilerOptionsPop.inc
+++ b/Lib/Protocols/IdCompilerOptionsPop.inc
@@ -3,6 +3,7 @@
     {$POP}
   {$ELSE}
     {$IFDEF DCC}
+      {$WARN POPOPT_WITH_NO_MATCHING OFF}
       {$POPOPT}
     {$ENDIF}
   {$ENDIF}

--- a/Lib/Protocols/IdCompilerOptionsPush.inc
+++ b/Lib/Protocols/IdCompilerOptionsPush.inc
@@ -3,6 +3,7 @@
     {$PUSH}
   {$ELSE}
     {$IFDEF DCC}
+      {$WARN MISSING_POPOPT OFF}
       {$PUSHOPT}
     {$ENDIF}
   {$ENDIF}

--- a/Lib/System/IdCompilerOptionsPop.inc
+++ b/Lib/System/IdCompilerOptionsPop.inc
@@ -3,6 +3,7 @@
     {$POP}
   {$ELSE}
     {$IFDEF DCC}
+      {$WARN POPOPT_WITH_NO_MATCHING OFF}
       {$POPOPT}
     {$ENDIF}
   {$ENDIF}

--- a/Lib/System/IdCompilerOptionsPush.inc
+++ b/Lib/System/IdCompilerOptionsPush.inc
@@ -3,6 +3,7 @@
     {$PUSH}
   {$ELSE}
     {$IFDEF DCC}
+      {$WARN MISSING_POPOPT OFF}
       {$PUSHOPT}
     {$ENDIF}
   {$ENDIF}

--- a/Lib/System/IdStackWindows.pas
+++ b/Lib/System/IdStackWindows.pas
@@ -1186,7 +1186,9 @@ begin
       LPort := IndyStrToInt(AServiceName);
     except
       on EConvertError do begin
+        {$IFNDEF USE_NORETURN}
         LPort := -1;
+        {$ENDIF}
         IndyRaiseOuterException(EIdInvalidServiceName.CreateFmt(RSInvalidServiceName, [AServiceName]));
       end;
     end;

--- a/Lib/System/IdWship6.pas
+++ b/Lib/System/IdWship6.pas
@@ -466,7 +466,9 @@ begin
     GIA_EAI_SOCKTYPE:   Result := WSAESOCKTNOSUPPORT;
     GIA_EAI_SYSTEM:
       begin
+        {$IFNDEF USE_NORETURN}
         Result := 0; // avoid warning
+        {$ENDIF}
         IndyRaiseLastError;
       end;
     else


### PR DESCRIPTION
Delphi doesn't look outside the .inc file when it warns about $PUSHOPT or $POPOPT not being paired, so this selectively disables those warnings within the .inc files.

Also removed a couple of unused assignments that were triggering warnings when noreturn is supported.